### PR TITLE
Releases/2.x

### DIFF
--- a/src/main/groovy/com/intershop/gradle/scm/services/ScmLocalService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/ScmLocalService.groovy
@@ -20,6 +20,7 @@ import com.intershop.gradle.scm.extension.ScmExtension
 import com.intershop.gradle.scm.utils.BranchType
 import com.intershop.gradle.scm.utils.PrefixConfig
 import com.intershop.gradle.scm.utils.ScmType
+
 import groovy.transform.CompileStatic
 
 /**
@@ -128,7 +129,7 @@ abstract class ScmLocalService {
     void setFeatureBranchName(String branch) {
         def branchCheck = branch =~ /^\d+(\.\d+)?(\.\d+)?(\.\d+)?(-.*)?/
         if (branchCheck.matches() && branchCheck.groupCount() > 3) {
-            featureBranchName = ((branchCheck[0] as List)[(branchCheck[0] as List).size() - 1].toString().substring(1))
+            featureBranchName = ((branchCheck[0] as List)[(branchCheck[0] as List).size() - 1].toString())
         } else {
             featureBranchName = branch
         }

--- a/src/main/groovy/com/intershop/gradle/scm/services/ScmVersionService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/ScmVersionService.groovy
@@ -15,6 +15,11 @@
  */
 package com.intershop.gradle.scm.services
 
+import static com.intershop.release.version.VersionExtension.LOCAL
+import static com.intershop.release.version.VersionExtension.SNAPSHOT
+
+import org.gradle.api.GradleException
+
 import com.intershop.gradle.scm.extension.VersionExtension
 import com.intershop.gradle.scm.services.git.GitLocalService
 import com.intershop.gradle.scm.utils.BranchType
@@ -24,11 +29,8 @@ import com.intershop.gradle.scm.version.VersionTag
 import com.intershop.release.version.DigitPos
 import com.intershop.release.version.ParserException
 import com.intershop.release.version.Version
-import groovy.util.logging.Slf4j
-import org.gradle.api.GradleException
 
-import static com.intershop.release.version.VersionExtension.SNAPSHOT
-import static com.intershop.release.version.VersionExtension.LOCAL
+import groovy.util.logging.Slf4j
 
 /**
  * This is the container for the remote access to the used SCM of a project.
@@ -225,6 +227,11 @@ trait ScmVersionService {
                 versionObject.scmPath, versionObject.version, versionObject.changed, versionObject.version.buildMetadata,
                 versionObject.isFromBranchName(), versionObject.defaultVersion)
 
+        // In case the branch or tag contains a version and nothing has changed, then we don't increase the versions.
+        if (localService.withVersion && !versionObject.changed) {
+            return versionObject.version
+        }
+        
         if((! versionObject.changed && versionObject.isFromBranchName()) || versionObject.defaultVersion) {
             return versionObject.version
         }

--- a/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
@@ -88,7 +88,7 @@ class GitLocalService extends ScmLocalService{
                 setFeatureBranchName((mbb[0] as List)[(mbb[0] as List).size() - 1].toString())
             } else if(msb.matches() && msb.count == 1) {
                 branchType = BranchType.branch
-                def branchCheck = branchName =~ /^\d+(\.\d+)?(\.\d+)?(\.\d+)?(-.*)?/
+                def branchCheck = branchName =~ /^${prefixes.getStabilizationPrefix()}${prefixes.getBranchPrefixSeperator()}\d+(\.\d+)?(\.\d+)?(\.\d+)?(-.*)?/
                 withVersion = branchCheck.matches()
             } else {
                 branchType = BranchType.featureBranch

--- a/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
@@ -15,18 +15,19 @@
  */
 package com.intershop.gradle.scm.services.git
 
-import com.intershop.gradle.scm.extension.ScmExtension
-import com.intershop.gradle.scm.services.ScmLocalService
-import com.intershop.gradle.scm.utils.BranchType
-import groovy.transform.CompileDynamic
-import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.LogCommand
 import org.eclipse.jgit.api.Status
 import org.eclipse.jgit.lib.*
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk
+
+import com.intershop.gradle.scm.extension.ScmExtension
+import com.intershop.gradle.scm.services.ScmLocalService
+import com.intershop.gradle.scm.utils.BranchType
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 
 @Slf4j
 @CompileStatic
@@ -97,14 +98,12 @@ class GitLocalService extends ScmLocalService{
         log.info('Initial branch type is {}', branchType)
         
         String tn = checkHeadForTag()
-        if(tn) {
+        if(branchType == branchType.detachedHead && tn) {
             branchType = BranchType.tag
             branchName = tn
             log.info('Updated branch name is {}', branchName)
             log.info('Updated branch type is {}', branchType)
         }
-
-        log.info('Branch name is {}', branchName)
 
         Config config = gitRepo.getConfig()
         remoteUrl = config.getString('remote', 'origin', 'url')

--- a/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
@@ -159,8 +159,10 @@ class GitLocalService extends ScmLocalService{
         String rvTagName = ''
         RevWalk rw = new RevWalk(repository)
 
-        gitRepo.getRefDatabase().getRefsByPrefix(Constants.R_TAGS).each {Ref ref ->
-            if(ObjectId.toString(rw.parseCommit(ref.objectId).id) == getRevID()) {
+        String headRevID = getRevID()
+        List<Ref> tagRefs = gitRepo.getRefDatabase().getRefsByPrefix(Constants.R_TAGS) 
+        tagRefs.each {Ref ref ->
+            if(ObjectId.toString(rw.parseCommit(ref.objectId).id) == headRevID) {
                 rvTagName = ref.name.substring(Constants.R_TAGS.length())
             }
         }

--- a/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
@@ -15,18 +15,19 @@
  */
 package com.intershop.gradle.scm.services.git
 
-import com.intershop.gradle.scm.extension.ScmExtension
-import com.intershop.gradle.scm.services.ScmLocalService
-import com.intershop.gradle.scm.utils.BranchType
-import groovy.transform.CompileDynamic
-import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.LogCommand
 import org.eclipse.jgit.api.Status
 import org.eclipse.jgit.lib.*
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk
+
+import com.intershop.gradle.scm.extension.ScmExtension
+import com.intershop.gradle.scm.services.ScmLocalService
+import com.intershop.gradle.scm.utils.BranchType
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 
 @Slf4j
 @CompileStatic
@@ -64,6 +65,7 @@ class GitLocalService extends ScmLocalService{
         gitClient = new Git(gitRepo)
 
         branchName = gitRepo.getBranch()
+        log.info('Initial branch name is {}', branchName)
 
         if(branchName == 'master') {
             branchType = BranchType.trunk
@@ -92,14 +94,15 @@ class GitLocalService extends ScmLocalService{
                 setFeatureBranchName(branchName)
             }
         }
-
+        log.info('Initial branch type is {}', branchType)
+        
         String tn = checkHeadForTag()
-        if(tn) {
+        if(branchType == branchType.detachedHead && tn) {
             branchType = BranchType.tag
             branchName = tn
+            log.info('Updated branch name is {}', branchName)
+            log.info('Updated branch type is {}', branchType)
         }
-
-        log.info('Branch name is {}', branchName)
 
         Config config = gitRepo.getConfig()
         remoteUrl = config.getString('remote', 'origin', 'url')

--- a/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
@@ -154,8 +154,10 @@ class GitLocalService extends ScmLocalService{
         String rvTagName = ''
         RevWalk rw = new RevWalk(repository)
 
-        gitRepo.getRefDatabase().getRefsByPrefix(Constants.R_TAGS).each {Ref ref ->
-            if(ObjectId.toString(rw.parseCommit(ref.objectId).id) == getRevID()) {
+        String headRevID = getRevID()
+        List<Ref> tagRefs = gitRepo.getRefDatabase().getRefsByPrefix(Constants.R_TAGS) 
+        tagRefs.each {Ref ref ->
+            if(ObjectId.toString(rw.parseCommit(ref.objectId).id) == headRevID) {
                 rvTagName = ref.name.substring(Constants.R_TAGS.length())
             }
         }

--- a/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/git/GitLocalService.groovy
@@ -86,6 +86,7 @@ class GitLocalService extends ScmLocalService{
                 setFeatureBranchName((mbb[0] as List)[(mbb[0] as List).size() - 1].toString())
             } else if(msb.matches() && msb.count == 1) {
                 branchType = BranchType.branch
+                withVersion = true
             } else {
                 branchType = BranchType.featureBranch
                 setFeatureBranchName(branchName)

--- a/src/main/groovy/com/intershop/gradle/scm/services/git/GitVersionService.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/services/git/GitVersionService.groovy
@@ -407,13 +407,13 @@ class GitVersionService extends GitRemoteService implements ScmVersionService{
 
         refList.each { Ref ref ->
             RevCommit rc = walk.parseCommit(ref.objectId)
-            String name = ref.getName().toString()
-            String branchName = name.substring(name.lastIndexOf('/') + 1)
+            String name = ref.getName()
+            String branchName = branchFilter.getBranchNameStr(name)
 
             if(branchName != 'master') {
                 String version = branchFilter.getVersionStr(branchName)
                 if(version) {
-                    rv.put(ObjectId.toString(rc), new BranchObject(ObjectId.toString(rc), version, name.substring(name.lastIndexOf('/') + 1)))
+                    rv.put(ObjectId.toString(rc), new BranchObject(ObjectId.toString(rc), version, branchName))
                 }
             }
         }

--- a/src/main/groovy/com/intershop/gradle/scm/version/AbstractBranchFilter.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/version/AbstractBranchFilter.groovy
@@ -18,6 +18,22 @@ package com.intershop.gradle.scm.version
 
 abstract class AbstractBranchFilter {
 
-    abstract String getVersionStr(String branch)
+    /**
+     * Analyses the input parameter with the created filter and returns a valid
+     * version string or an empty string, if the input is not valid or does not match.
+     *
+     * @param test input string
+     * @return a valid version string or an empty string
+     */
+    abstract String getVersionStr(String test)
+
+    /**
+     * Analyses the input parameter with the created filter and returns the branch 
+     * name as string or an empty string, if the input is not valid or does not match.
+     *
+     * @param test input string
+     * @return the branch name as string or an empty string
+     */
+    abstract String getBranchNameStr(String test)
 
 }

--- a/src/main/groovy/com/intershop/gradle/scm/version/ReleaseFilter.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/version/ReleaseFilter.groovy
@@ -20,6 +20,7 @@ import com.intershop.gradle.scm.utils.BranchType
 import com.intershop.gradle.scm.utils.PrefixConfig
 import com.intershop.release.version.Version
 import com.intershop.release.version.VersionType
+
 import groovy.util.logging.Slf4j
 
 @Slf4j
@@ -56,5 +57,14 @@ class ReleaseFilter extends AbstractBranchFilter {
 
         return ''
     }
+
+    
+    @Override
+	// Never used for this subclass
+    public String getBranchNameStr(String test)
+    {
+        return ''
+    }
+
 }
 

--- a/src/main/groovy/com/intershop/gradle/scm/version/ScmBranchFilter.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/version/ScmBranchFilter.groovy
@@ -18,6 +18,7 @@ package com.intershop.gradle.scm.version
 import com.intershop.gradle.scm.utils.BranchType
 import com.intershop.gradle.scm.utils.PrefixConfig
 import com.intershop.release.version.Version
+
 import groovy.util.logging.Slf4j
 
 /**
@@ -31,6 +32,8 @@ class ScmBranchFilter extends AbstractBranchFilter {
      */
     private static final String versionregex = '(\\d+(\\.\\d+)?(\\.\\d+)?(\\.\\d+)?)'
 
+    private String branchName = ''
+    
     // regex pattern will be created with some predefined variables
     private def regexPattern
     // feature branch key
@@ -74,6 +77,7 @@ class ScmBranchFilter extends AbstractBranchFilter {
     ScmBranchFilter(BranchType versionBranchtype, PrefixConfig prefixes, String branchFilterName = '', BranchType branchFilterType , String featureBranch = '', int patternDigits = 2) {
         String[] vdata = new String[4]
         this.prefixes = prefixes
+        this.branchName = branchFilterName
 
         log.debug("Create filter for type:${versionBranchtype}, name:${branchFilterName}, featurebranch:${featureBranch}, pattern:${patternDigits}")
 
@@ -159,4 +163,16 @@ class ScmBranchFilter extends AbstractBranchFilter {
 
         return ''
     }
+
+
+    @Override
+    public String getBranchNameStr(String test)
+    {
+        if (test.endsWith(this.branchName)) {
+            return this.branchName
+        }
+        
+        return ''
+    }
+    
 }

--- a/src/main/groovy/com/intershop/gradle/scm/version/ScmBranchFilter.groovy
+++ b/src/main/groovy/com/intershop/gradle/scm/version/ScmBranchFilter.groovy
@@ -116,7 +116,7 @@ class ScmBranchFilter extends AbstractBranchFilter {
 
         switch (versionBranchtype) {
             case BranchType.branch:
-                patternString += '$)'
+                patternString += ')$'
                 break
             case BranchType.featureBranch:
                 patternString += ")"

--- a/src/test/groovy/com/intershop/gradle/scm/services/git/GitRemoteServiceSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/scm/services/git/GitRemoteServiceSpec.groovy
@@ -15,18 +15,20 @@
  */
 package com.intershop.gradle.scm.services.git
 
-import com.intershop.gradle.scm.ScmVersionPlugin
-import com.intershop.gradle.scm.extension.ScmExtension
-import com.intershop.gradle.scm.test.utils.AbstractScmSpec
-import com.intershop.gradle.scm.utils.BranchObject
-import com.intershop.gradle.scm.utils.ScmUser
-import com.intershop.gradle.scm.version.AbstractBranchFilter
-import com.intershop.gradle.test.util.TestDir
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TestName
+
+import com.intershop.gradle.scm.ScmVersionPlugin
+import com.intershop.gradle.scm.extension.ScmExtension
+import com.intershop.gradle.scm.test.utils.AbstractScmSpec
+import com.intershop.gradle.scm.utils.BranchObject
+import com.intershop.gradle.scm.utils.ScmUser
+import com.intershop.gradle.scm.version.ScmBranchFilter
+import com.intershop.gradle.test.util.TestDir
+
 import spock.lang.Requires
 import spock.lang.Unroll
 
@@ -54,7 +56,7 @@ class GitRemoteServiceSpec extends AbstractScmSpec {
                 new ScmUser(System.properties['gituser'].toString(), System.properties['gitpasswd'].toString()))
 
         Map<String, BranchObject> map = srs.getTagMap(
-                new AbstractBranchFilter() {
+                new ScmBranchFilter() {
                     @Override
                     String getVersionStr(String branch) {
                         def versionGroup = (branch =~ /(\d+\.?\d+\.?\d+\.?\d*-?([A-za-z]+\.?\d+$)?)/)

--- a/src/test/groovy/com/intershop/gradle/scm/services/svn/SvnRemoteServiceSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/scm/services/svn/SvnRemoteServiceSpec.groovy
@@ -15,18 +15,20 @@
  */
 package com.intershop.gradle.scm.services.svn
 
-import com.intershop.gradle.scm.ScmVersionPlugin
-import com.intershop.gradle.scm.extension.ScmExtension
-import com.intershop.gradle.scm.test.utils.AbstractScmSpec
-import com.intershop.gradle.scm.utils.BranchObject
-import com.intershop.gradle.scm.utils.ScmUser
-import com.intershop.gradle.scm.version.AbstractBranchFilter
-import com.intershop.gradle.test.util.TestDir
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TestName
+
+import com.intershop.gradle.scm.ScmVersionPlugin
+import com.intershop.gradle.scm.extension.ScmExtension
+import com.intershop.gradle.scm.test.utils.AbstractScmSpec
+import com.intershop.gradle.scm.utils.BranchObject
+import com.intershop.gradle.scm.utils.ScmUser
+import com.intershop.gradle.scm.version.ScmBranchFilter
+import com.intershop.gradle.test.util.TestDir
+
 import spock.lang.Requires
 import spock.lang.Unroll
 
@@ -53,7 +55,7 @@ class SvnRemoteServiceSpec extends AbstractScmSpec {
                 new ScmUser(System.properties['svnuser'].toString(), System.properties['svnpasswd'].toString()))
 
         Map<String, BranchObject> map = srs.getTagMap(
-                new AbstractBranchFilter() {
+                new ScmBranchFilter() {
                     @Override
                     String getVersionStr(String branch) {
                         def versionGroup = (branch =~ /(\d+\.?\d+\.?\d+\.?\d*-?([A-za-z]+\.?\d+$)?)/)


### PR DESCRIPTION
Some changes/fixes we needed to allow proper version calculation. Would be great to see a new 2.x version published with these changes included.

I've also seen usage of replace("/", "\\/") in the branch filter. Just wanted to remark that this replace doesn't work in case the prefix(es) is define as escaped character, e.g.:

`        branchPrefixSeperator = '\/'`

So maybe it would be better to remove those replace() calls and just update documentation for prefix definitions?



